### PR TITLE
pyrogram to pyrofork

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -2,8 +2,6 @@
 
 from aiohttp import web
 from plugins import web_server
-
-import pyromod.listen
 from pyrogram import Client
 from pyrogram.enums import ParseMode
 import sys

--- a/config.py
+++ b/config.py
@@ -41,7 +41,7 @@ FORCE_SUB_CHANNEL2 = int(os.environ.get("FORCE_SUB_CHANNEL2", "-1001644866777"))
 TG_BOT_WORKERS = int(os.environ.get("TG_BOT_WORKERS", "4"))
 
 #start message
-START_MSG = os.environ.get("START_MESSAGE", "<b>ʙᴀᴋᴋᴀᴀᴀ!! {first}\n\n ɪ ᴀᴍ ғɪʟᴇ sᴛᴏʀᴇ ʙᴏᴛ, ɪ ᴄᴀɴ sᴛᴏʀᴇ ᴘʀɪᴠᴀᴛᴇ ғɪʟᴇs ɪɴ sᴘᴇᴄɪғɪᴇᴅ ᴄʜᴀɴɴᴇʟ ᴀɴᴅ ᴏᴛʜᴇʀ ᴜsᴇʀs ᴄᴀɴ ᴀᴄᴄᴇss ɪᴛ ғʀᴏᴍ sᴘᴇᴄɪᴀʟ ʟɪɴᴋ.</b>")
+START_MSG = os.environ.get("START_MESSAGE", "ʜᴇʟʟᴏ {first} <blockquote>ɪ ᴀᴍ ғɪʟᴇ sᴛᴏʀᴇ ʙᴏᴛ, ɪ ᴄᴀɴ sᴛᴏʀᴇ ᴘʀɪᴠᴀᴛᴇ ғɪʟᴇs ɪɴ sᴘᴇᴄɪғɪᴇᴅ ᴄʜᴀɴɴᴇʟ ᴀɴᴅ ᴏᴛʜᴇʀ ᴜsᴇʀs ᴄᴀɴ ᴀᴄᴄᴇss ɪᴛ ғʀᴏᴍ sᴘᴇᴄɪᴀʟ ʟɪɴᴋ.</blockquote>")
 try:
     ADMINS=[6376328008]
     for x in (os.environ.get("ADMINS", "5115691197 6273945163 6103092779 5231212075").split()):
@@ -50,7 +50,7 @@ except ValueError:
         raise Exception("Your Admins list does not contain valid integers.")
 
 #Force sub message 
-FORCE_MSG = os.environ.get("FORCE_SUB_MESSAGE", "ʜᴇʟʟᴏ {first}\n\n<b>ᴊᴏɪɴ ᴏᴜʀ ᴄʜᴀɴɴᴇʟs ᴀɴᴅ ᴛʜᴇɴ ᴄʟɪᴄᴋ ᴏɴ ʀᴇʟᴏᴀᴅ button ᴛᴏ ɢᴇᴛ ʏᴏᴜʀ ʀᴇǫᴜᴇꜱᴛᴇᴅ ꜰɪʟᴇ.</b>")
+FORCE_MSG = os.environ.get("FORCE_SUB_MESSAGE", "ʜᴇʟʟᴏ {first}\n\n<blockquote>ᴊᴏɪɴ ᴏᴜʀ ᴄʜᴀɴɴᴇʟs ᴀɴᴅ ᴛʜᴇɴ ᴄʟɪᴄᴋ ᴏɴ ʀᴇʟᴏᴀᴅ button ᴛᴏ ɢᴇᴛ ʏᴏᴜʀ ʀᴇǫᴜᴇꜱᴛᴇᴅ ꜰɪʟᴇ.</blockquote>")
 
 #set your Custom Caption here, Keep None for Disable Custom Caption
 CUSTOM_CAPTION = os.environ.get("CUSTOM_CAPTION", "<b>• ʙʏ @OtakuFlix_Network</b>")

--- a/main.py
+++ b/main.py
@@ -1,6 +1,3 @@
 from bot import Bot
-import pyrogram.utils
-
-pyrogram.utils.MIN_CHANNEL_ID = -1009147483647
 
 Bot().run()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 # --- For-Bot-Working --------- #
-pyrogram
+tzdata
+git+https://github.com/KurimuzonAkuma/pyrogram.git@v2.1.17#egg=pyrogram
 TgCrypto
 pyromod==1.5
 # --- For-Database ------------ #

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,6 @@
 # --- For-Bot-Working --------- #
-tzdata
-git+https://github.com/KurimuzonAkuma/pyrogram.git@v2.1.17#egg=pyrogram
+pyrofork
 TgCrypto
-pyromod==1.5
 # --- For-Database ------------ #
 pymongo
 dnspython


### PR DESCRIPTION
By switching the program to `**pyofork**`, we can fix the peer error and add support for the latest Telegram channel IDs and text formats, such as quotes. Remove `**pyromod**==1.5` from `requirements.txt` and the imports from the code. For a demo bot reference, check out @AV_File_Sharing_Bot.